### PR TITLE
Add an age transformer for consistent definitions across platforms

### DIFF
--- a/lore/transformers.py
+++ b/lore/transformers.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from abc import ABCMeta, abstractmethod
 
 import csv
+import datetime
 import os
 import re
 
@@ -39,6 +40,35 @@ class DateTime(Base):
     def transform(self, data):
         return getattr(data[self.column].dt, self.operator)
 
+
+class Age(Base):
+    def __init__(self, column, unit='seconds'):
+        super(Age, self).__init__(column)
+        self.unit = unit
+
+    def transform(self, data):
+        age = (datetime.datetime.now() - data[self.column])
+        if self.unit in ['nanosecond', 'nanoseconds']:
+            return age
+        
+        seconds = age.dt.total_seconds()
+        if self.unit in ['second', 'seconds']:
+            return seconds
+        if self.unit in ['minute', 'minutes']:
+            return seconds / 60
+        if self.unit in ['hour', 'hours']:
+            return seconds / 3600
+        if self.unit in ['day', 'days']:
+            return seconds / 86400
+        if self.unit in ['week', 'weeks']:
+            return seconds / 604800
+        if self.unit in ['month', 'months']:
+            return seconds / 2592000
+        if self.unit in ['year', 'years']:
+            return seconds / 31536000
+
+        raise NameError('Unknown unit: %s' % self.unit)
+        
 
 class Log(Base):
     def transform(self, data):

--- a/tests/unit/test_transformers.py
+++ b/tests/unit/test_transformers.py
@@ -78,3 +78,13 @@ class TestDateTime(unittest.TestCase):
         data = pandas.DataFrame({'test': [datetime.datetime(2016, 12, 31), datetime.date(2017, 1, 1)]})
         transformed = transformer.transform(data)
         self.assertEqual(transformed.iloc[0] + 1, transformed.iloc[1])
+
+
+class TestAge(unittest.TestCase):
+    def test_transform_age(self):
+        transformer = lore.transformers.Age('test', 'days')
+        yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
+
+        data = pandas.DataFrame({'test': [datetime.datetime.now(), yesterday]})
+        transformed = transformer.transform(data)
+        self.assertEqual(transformed.astype(int).tolist(), [0, 1])


### PR DESCRIPTION
### What
A tranformer for age

### Why
Different units of time require standardization... e.g. is a month 28/30/31 days or dependent on the month?

### Who
@jeremystan 
cc @shiftb 