### PR TITLE
Add tags to encoders

### DIFF
--- a/lore/encoders.py
+++ b/lore/encoders.py
@@ -26,7 +26,7 @@ class Base(object):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, column, name=None, dtype=numpy.uint32, embed_scale=1):
+    def __init__(self, column, name=None, dtype=numpy.uint32, embed_scale=1, tags=[]):
         """
         :param column: the index name of a column in a dataframe, or a Transformer
         :param name: an optional debugging hint, otherwise a default will be supplied
@@ -36,7 +36,8 @@ class Base(object):
         self.column = column
         self.dtype = dtype
         self.embed_scale = embed_scale
-
+        self.tags = tags
+        
         if name:
             self.name = name
         else:
@@ -162,7 +163,7 @@ class Equals(Base):
     
     see also: numpy.equal
     """
-    def __init__(self, column, other, name=None, embed_scale=1):
+    def __init__(self, column, other, name=None, embed_scale=1, tags=[]):
         """
         :param column: the index name of a column in a DataFrame, or a Transformer
         :param other: the index name of a column in a DataFrame, or a Transformer
@@ -172,7 +173,7 @@ class Equals(Base):
             column_name = column.name if isinstance(column, lore.transformers.Base) else column
             other_name = other.name if isinstance(other, lore.transformers.Base) else other
             name = 'match_' + column_name + '_and_' + other_name
-        super(Equals, self).__init__(column=column, name=name, embed_scale=embed_scale)
+        super(Equals, self).__init__(column=column, name=name, embed_scale=embed_scale, tags=tags)
         self.other = other
 
     def transform(self, data):
@@ -195,8 +196,8 @@ class Equals(Base):
 class Continuous(Base):
     """Abstract Base Class for encoders that return continuous values"""
     
-    def __init__(self, column, name=None, dtype=numpy.float16, embed_scale=1):
-        super(Continuous, self).__init__(column, name=name, dtype=dtype, embed_scale=embed_scale)
+    def __init__(self, column, name=None, dtype=numpy.float16, embed_scale=1, tags=[]):
+        super(Continuous, self).__init__(column, name=name, dtype=dtype, embed_scale=embed_scale, tags=tags)
 
     def cardinality(self):
         raise ValueError('Continous values have infinite cardinality')
@@ -222,8 +223,8 @@ class Uniform(Continuous):
     range will be capped from 0 to 1.
     """
 
-    def __init__(self, column, name=None, dtype=numpy.float16, embed_scale=1):
-        super(Uniform, self).__init__(column, name=name, dtype=dtype, embed_scale=embed_scale)
+    def __init__(self, column, name=None, dtype=numpy.float16, embed_scale=1, tags=[]):
+        super(Uniform, self).__init__(column, name=name, dtype=dtype, embed_scale=embed_scale, tags=tags)
         self.__min = float('nan')
         self.__range = float('nan')
         self.missing_value = 0
@@ -257,8 +258,8 @@ class Norm(Continuous):
     exceeds the fit range will be capped at the fit range.
     """
 
-    def __init__(self, column, name=None, dtype=numpy.float16, embed_scale=1):
-        super(Norm, self).__init__(column, name, dtype, embed_scale)
+    def __init__(self, column, name=None, dtype=numpy.float16, embed_scale=1, tags=[]):
+        super(Norm, self).__init__(column, name, dtype, embed_scale, tags=tags)
         self.__min = float('nan')
         self.__max = float('nan')
         self.__mean = float('nan')
@@ -298,8 +299,8 @@ class Discrete(Base):
     bins + 1.
     """
     
-    def __init__(self, column, name=None, bins=10, embed_scale=1):
-        super(Discrete, self).__init__(column, name, embed_scale=embed_scale)
+    def __init__(self, column, name=None, bins=10, embed_scale=1, tags=[]):
+        super(Discrete, self).__init__(column, name, embed_scale=embed_scale, tags=tags)
         self.__norm = bins - 1
         self.__min = float('nan')
         self.__range = float('nan')
@@ -347,8 +348,8 @@ class Enum(Base):
     exceed previously fit max are given a unique value. Missing values are
     also distinctly encoded.
     """
-    def __init__(self, column, name=None, embed_scale=1):
-        super(Enum, self).__init__(column, name, embed_scale=embed_scale)
+    def __init__(self, column, name=None, embed_scale=1, tags=[]):
+        super(Enum, self).__init__(column, name, embed_scale=embed_scale, tags=tags)
         self.__max = None
         self.unfit_value = None
         self.missing_value = None
@@ -386,11 +387,11 @@ class Quantile(Base):
     Values the excede the upper and lower bound fit, will be placed into
     distinct bins, as well nans.
     """
-    def __init__(self, column, name=None, quantiles=10, embed_scale=1):
+    def __init__(self, column, name=None, quantiles=10, embed_scale=1, tags=[]):
         """
         :param quantiles: the number of bins
         """
-        super(Quantile, self).__init__(column, name, embed_scale=embed_scale)
+        super(Quantile, self).__init__(column, name, embed_scale=embed_scale, tags=tags)
         self.quantiles = quantiles
         self.missing_value = self.quantiles + 2
         self.upper_bound = None
@@ -441,12 +442,12 @@ class Unique(Base):
     the stratify column the encoded value appears with.
     """
     
-    def __init__(self, column, name=None, minimum_occurrences=1, stratify=None, embed_scale=1):
+    def __init__(self, column, name=None, minimum_occurrences=1, stratify=None, embed_scale=1, tags=[]):
         """
         :param minimum_occurrences: ignore ids with less than this many occurrences
         :param stratify: compute minimum occurrences over data column with this name
         """
-        super(Unique, self).__init__(column, name, embed_scale=embed_scale)
+        super(Unique, self).__init__(column, name, embed_scale=embed_scale, tags=tags)
         self.minimum_occurrences = minimum_occurrences
         self.map = None
         self.inverse = None
@@ -500,7 +501,7 @@ class Token(Unique):
     """
     PUNCTUATION_FILTER = re.compile(r'\W+\s\W+|\W+(\s|$)|(\s|^)\W+', re.UNICODE)
     
-    def __init__(self, column, name=None, sequence_length=None, minimum_occurrences=1, embed_scale=1):
+    def __init__(self, column, name=None, sequence_length=None, minimum_occurrences=1, embed_scale=1, tags=[]):
         """
         :param sequence_length: truncates tokens after sequence_length
         :param minimum_occurrences: ignore tokens with less than this many occurrences
@@ -509,7 +510,8 @@ class Token(Unique):
             column,
             name=name,
             minimum_occurrences=minimum_occurrences,
-            embed_scale=embed_scale
+            embed_scale=embed_scale,
+            tags=tags
         )
         self.sequence_length = sequence_length
     
@@ -622,8 +624,8 @@ class MiddleOut(Base):
 
     """
     
-    def __init__(self, column, name=None, depth=None):
-        super(MiddleOut, self).__init__(column, name)
+    def __init__(self, column, name=None, depth=None, tags=[]):
+        super(MiddleOut, self).__init__(column, name, tags=tags)
         self.depth = depth
         self.dtype = self._type_from_cardinality()
         


### PR DESCRIPTION
### What
Tags for encoders

### Why
`(Enum('column', tags={'foo'}), Enum('other', tags={'bar'})` allows annotating encoders to create subsets for different processing in pipelines and estimator layers.

### Who
@jeremystan 
cc @shiftb 