### PR TITLE
[WIP] Minor README enhancement: External links for libraries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,7 @@ Lore provides python modules to standardize Machine Learning techniques across m
 
 Core Functionality
 ------------------
-- **lore.models** are compatibility wrappers for your favorite library — `Keras <https://keras.io/>`_, `XGBoost <https://https://xgboost.readthedocs.io/>`_, `SciKit Learn <http://scikit-learn.org/stable/>`_)). They come with reasonable defaults for rough draft training out of the box.
+- **lore.models** are compatibility wrappers for your favorite library — `Keras <https://keras.io/>`_, `XGBoost <https://https://xgboost.readthedocs.io/>`_, `SciKit Learn <http://scikit-learn.org/stable/>`_. They come with reasonable defaults for rough draft training out of the box.
 - **lore.pipelines** fetch, encode, and split data into training/test sets for models. A single pipeline will have one Encoder per feature in the model.
 - **lore.encoders** operate within Pipelines to transform a single feature into an optimal representation for learning.
 - **lore.transformers** provide common operations, like extracting the area code from a free text phone number. They can be chained together inside encoders. They efficiently

--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,7 @@ Lore provides python modules to standardize Machine Learning techniques across m
 
 Core Functionality
 ------------------
-- **lore.models** are compatibility wrappers for your favorite library (`Keras <https://keras.io/>`_ (TensorFlow/Theano/CNTK), `XGBoost <https://https://xgboost.readthedocs.io/>`_, `SciKit Learn <http://scikit-learn.org/stable/>`_)). They come with reasonable defaults for rough draft training out of the box.
+- **lore.models** are compatibility wrappers for your favorite library — `Keras <https://keras.io/>`_, `XGBoost <https://https://xgboost.readthedocs.io/>`_, `SciKit Learn <http://scikit-learn.org/stable/>`_)). They come with reasonable defaults for rough draft training out of the box.
 - **lore.pipelines** fetch, encode, and split data into training/test sets for models. A single pipeline will have one Encoder per feature in the model.
 - **lore.encoders** operate within Pipelines to transform a single feature into an optimal representation for learning.
 - **lore.transformers** provide common operations, like extracting the area code from a free text phone number. They can be chained together inside encoders. They efficiently
@@ -253,7 +253,7 @@ Use your favorite library in a lore project, just like you'd use them in any oth
 - `SciKit-Learn <http://scikit-learn.org/stable/>`_
 - `Jupyter Notebook <http://jupyter.org/>`_
 - `Pandas <https://pandas.pydata.org/>`_
-- `Numpy <http://www.numpy.org/`_
+- `Numpy <http://www.numpy.org/>`_
 - `Matplotlib <https://matplotlib.org/>`_, `ggplot <http://ggplot.yhathq.com/>`_, `plotnine <http://plotnine.readthedocs.io/en/stable/>`_
 - `SQLAlchemy <https://www.sqlalchemy.org/>`_, `Psycopg2 <http://initd.org/psycopg/docs/>`_
 - Hub

--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,7 @@ Features
 --------
 
 - Models support hyper parameter search over estimators with a data pipeline. They will efficiently utilize multiple GPUs (if available) with a couple different strategies, and can be saved and distributed for horizontal scalability.
-- Estimators from multiple packages are supported: `Keras <https://keras.io/>`_ (TensorFlow/Theano
-Theano/CNTK), `XGBoost <https://https://xgboost.readthedocs.io/>`_ and `SciKit Learn <http://scikit-learn.org/stable/>`_. They can all be subclassed with build, fit or predict overridden to completely customize your algorithm and architecture, while still benefiting from everything else.
+- Estimators from multiple packages are supported: `Keras <https://keras.io/>`_ (TensorFlow/Theano/CNTK), `XGBoost <https://https://xgboost.readthedocs.io/>`_ and `SciKit Learn <http://scikit-learn.org/stable/>`_. They can all be subclassed with build, fit or predict overridden to completely customize your algorithm and architecture, while still benefiting from everything else.
 - Pipelines avoid information leaks between train and test sets, and one pipeline allows experimentation with many different estimators. A disk based pipeline is available if you exceed your machines available RAM.
 - Transformers standardize advanced feature engineering. For example, convert an American first name to its statistical age or gender using US Census data. Extract the geographic area code from a free form phone number string. Common date, time and string operations are supported efficiently through pandas.
 - Encoders offer robust input to your estimators, and avoid common problems with missing and long tail values. They are well tested to save you from garbage in/garbage out.
@@ -226,8 +225,7 @@ Lore provides python modules to standardize Machine Learning techniques across m
 
 Core Functionality
 ------------------
-- **lore.models** are compatibility wrappers for your favorite library (`Keras <https://keras.io/>`_ (TensorFlow/Theano
-Theano/CNTK), `XGBoost <https://https://xgboost.readthedocs.io/>`_, `SciKit Learn <http://scikit-learn.org/stable/>`_)). They come with reasonable defaults for rough draft training out of the box.
+- **lore.models** are compatibility wrappers for your favorite library (`Keras <https://keras.io/>`_ (TensorFlow/Theano/CNTK), `XGBoost <https://https://xgboost.readthedocs.io/>`_, `SciKit Learn <http://scikit-learn.org/stable/>`_)). They come with reasonable defaults for rough draft training out of the box.
 - **lore.pipelines** fetch, encode, and split data into training/test sets for models. A single pipeline will have one Encoder per feature in the model.
 - **lore.encoders** operate within Pipelines to transform a single feature into an optimal representation for learning.
 - **lore.transformers** provide common operations, like extracting the area code from a free text phone number. They can be chained together inside encoders. They efficiently
@@ -250,8 +248,7 @@ Integrated Libraries
 --------------------
 Use your favorite library in a lore project, just like you'd use them in any other python project. They'll play nicely together.
 
-- `Keras <https://keras.io/>`_ (TensorFlow/Theano
-Theano/CNTK) + `Tensorboard <https://www.tensorflow.org/programmers_guide/summaries_and_tensorboard>`_
+- `Keras <https://keras.io/>`_ (TensorFlow/Theano/CNTK) + `Tensorboard <https://www.tensorflow.org/programmers_guide/summaries_and_tensorboard>`_
 - `XGBoost <https://https://xgboost.readthedocs.io/>`_
 - `SciKit-Learn <http://scikit-learn.org/stable/>`_
 - `Jupyter Notebook <http://jupyter.org/>`_

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,8 @@ Features
 --------
 
 - Models support hyper parameter search over estimators with a data pipeline. They will efficiently utilize multiple GPUs (if available) with a couple different strategies, and can be saved and distributed for horizontal scalability.
-- Estimators from multiple packages are supported: Keras, XGBoost and SciKit Learn. They can all be subclassed with build, fit or predict overridden to completely customize your algorithm and architecture, while still benefiting from everything else.
+- Estimators from multiple packages are supported: `Keras <https://keras.io/>`_ (TensorFlow/Theano
+Theano/CNTK), `XGBoost <https://https://xgboost.readthedocs.io/>`_ and `SciKit Learn <http://scikit-learn.org/stable/>`_. They can all be subclassed with build, fit or predict overridden to completely customize your algorithm and architecture, while still benefiting from everything else.
 - Pipelines avoid information leaks between train and test sets, and one pipeline allows experimentation with many different estimators. A disk based pipeline is available if you exceed your machines available RAM.
 - Transformers standardize advanced feature engineering. For example, convert an American first name to its statistical age or gender using US Census data. Extract the geographic area code from a free form phone number string. Common date, time and string operations are supported efficiently through pandas.
 - Encoders offer robust input to your estimators, and avoid common problems with missing and long tail values. They are well tested to save you from garbage in/garbage out.
@@ -225,7 +226,8 @@ Lore provides python modules to standardize Machine Learning techniques across m
 
 Core Functionality
 ------------------
-- **lore.models** are compatibility wrappers for your favorite library (keras, xgboost, scikit). They come with reasonable defaults for rough draft training out of the box.
+- **lore.models** are compatibility wrappers for your favorite library (`Keras <https://keras.io/>`_ (TensorFlow/Theano
+Theano/CNTK), `XGBoost <https://https://xgboost.readthedocs.io/>`_, `SciKit Learn <http://scikit-learn.org/stable/>`_)). They come with reasonable defaults for rough draft training out of the box.
 - **lore.pipelines** fetch, encode, and split data into training/test sets for models. A single pipeline will have one Encoder per feature in the model.
 - **lore.encoders** operate within Pipelines to transform a single feature into an optimal representation for learning.
 - **lore.transformers** provide common operations, like extracting the area code from a free text phone number. They can be chained together inside encoders. They efficiently
@@ -248,19 +250,20 @@ Integrated Libraries
 --------------------
 Use your favorite library in a lore project, just like you'd use them in any other python project. They'll play nicely together.
 
-- Keras/Tensorflow + Tensorboard
-- XGBoost
-- Scikit-Learn
-- Jupyter Notebook
-- Pandas
-- Numpy
-- Matplotlib, ggplot, plotnine
-- Sqlalchemy, Psycopg2
+- `Keras <https://keras.io/>`_ (TensorFlow/Theano
+Theano/CNTK) + `Tensorboard <https://www.tensorflow.org/programmers_guide/summaries_and_tensorboard>`_
+- `XGBoost <https://https://xgboost.readthedocs.io/>`_
+- `SciKit-Learn <http://scikit-learn.org/stable/>`_
+- `Jupyter Notebook <http://jupyter.org/>`_
+- `Pandas <https://pandas.pydata.org/>`_
+- `Numpy <http://www.numpy.org/`_
+- `Matplotlib <https://matplotlib.org/>`_, `ggplot <http://ggplot.yhathq.com/>`_, `plotnine <http://plotnine.readthedocs.io/en/stable/>`_
+- `SQLAlchemy <https://www.sqlalchemy.org/>`_, `Psycopg2 <http://initd.org/psycopg/docs/>`_
 - Hub
 
 Dev Ops
 -------
-There are many ways to manage python dependencies in development and production, and each has it's own pitfalls. Lore codifies a solution that “just works” with lore install, which exactly replicates what will be run in production.
+There are `many ways to manage python dependencies in development and production <http://docs.python-guide.org/en/latest/starting/installation/>`_, and each has it's own pitfalls. Lore codifies a solution that “just works” with lore install, which exactly replicates what will be run in production.
 
 **Python 2 & 3 compatibility**
 


### PR DESCRIPTION
## What

Making some of the mentions of external libs link to their sites/readmes.

## Why

Helps newbs who might be introduce to these things via lore.

----

## More?

If you like the gist of this, I'd be happy to go through for lots of other mentions and make them into links. (Of course not all READMEs need this treatment... I thought to do it here since `lore` has the admirable goal of making things more accessible to diverse audiences.)

Let me know?