### PR TITLE
small fix for multiprocess encoders

### DIFF
--- a/lore/pipelines/holdout.py
+++ b/lore/pipelines/holdout.py
@@ -93,7 +93,7 @@ class Base(object):
                 if self.multiprocessing:
                     pool = multiprocessing.Pool(self.workers)
                     results = []
-                    for encoder in self.encoders:
+                    for encoder in self._encoders:
                         results.append(pool.apply_async(self.fit, (encoder, self.training_data)))
                     self._encoders = [result.get() for result in results]
 


### PR DESCRIPTION
## What
Quick fix for `encoders`

## Why
Should use the private version from `get_encoder()`