### PR TITLE
from lore.estimators.holt_winters.holtwinters import additive

### DIFF
--- a/lore/estimators/holt_winters/__init__.py
+++ b/lore/estimators/holt_winters/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 from lore.env import require
 from lore.util import timed
-import lore.estimators.holt_winters.holtwinters
+from lore.estimators.holt_winters.holtwinters import additive
 
 require(lore.dependencies.SKLEARN)
 
@@ -20,7 +20,7 @@ class HoltWinters(BaseEstimator):
 
   @timed(logging.INFO)
   def fit(self, x, y=None):
-    results = holtwinters.additive(x, self.periodicity, self.forecasts,
+    results = additive(x, self.periodicity, self.forecasts,
       alpha=self.kwargs.get('alpha'),
       beta=self.kwargs.get('beta'),
       gamma=self.kwargs.get('gamma'))
@@ -30,5 +30,4 @@ class HoltWinters(BaseEstimator):
 
   @timed(logging.INFO)
   def predict(self, X):
-    return holtwinters.additive(X, self.periodicity, self.forecasts,
-      **self.params)[0]
+    return additive(X, self.periodicity, self.forecasts, **self.params)[0]


### PR DESCRIPTION
Modify the import to resolve undefined names which may raise NameError at runtime.

flake8 testing of https://github.com/instacart/lore on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lore/env.py:291:32: F821 undefined name 'unicode'
        config.readfp(StringIO(unicode(conf)))
                               ^
./lore/estimators/holt_winters/__init__.py:23:15: F821 undefined name 'holtwinters'
    results = holtwinters.additive(x, self.periodicity, self.forecasts,
              ^
./lore/estimators/holt_winters/__init__.py:33:12: F821 undefined name 'holtwinters'
    return holtwinters.additive(X, self.periodicity, self.forecasts,
           ^
3     F821 undefined name 'unicode'
3
```

## What


## Why

