### PR TITLE
Default gzip compression

### DIFF
--- a/lore/features/s3.py
+++ b/lore/features/s3.py
@@ -17,14 +17,14 @@ class S3(Base):
     def serialization(self):
         pass
 
-    def publish(self):
+    def publish(self, compression='gzip'):
         temp_file, temp_path = tempfile.mkstemp(dir=lore.env.DATA_DIR)
         data = self.get_data()
 
         if self.serialization() == 'csv':
-            data.to_csv(temp_path, index=False)
+            data.to_csv(temp_path, index=False, compression=compression)
         elif self.serialization() == 'pickle':
-            data.to_pickle(temp_path)
+            data.to_pickle(temp_path, compression=compression)
         else:
             raise "Invalid serialization"
         upload(temp_path, self.data_path())


### PR DESCRIPTION
## What
Enable compression for feature store

## Why
These files tend to be super big and would be efficient to gzip them for upload/download

cc @montanalow 