### PR TITLE
Bugfix: Enable copying files between file systems

### DIFF
--- a/lore/io/__init__.py
+++ b/lore/io/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pickle
 import re
+import shutil
 import tarfile
 import tempfile
 
@@ -106,7 +107,8 @@ def download(remote_url, local_path=None, cache=True, extract=False):
             except os.FileExistsError:
                 pass  # race to create
 
-        os.rename(temp_path, local_path)
+        shutil.copy(temp_path, local_path)
+        os.remove(temp_path)
 
         if extract:
             with timer('EXTRACT: %s' % local_path, logging.WARNING):


### PR DESCRIPTION
## What

Fix issue where copying between different file systems breaks data retrieval.

Running lore from, e.g., a dedicated /home partition seems to cause trouble when data is being copied from /tmp to /home/path/to/app. An error with the following signature is raised (full traceback below): `OSError: [Errno 18] Invalid cross-device link: '/tmp/tmpwl6lvhon' -> '/home/thomas/code/my_app/data/instacart_online_grocery_shopping_2017_05_01.tar.gz'`

## Why

`os.rename` only works if the source and destination path are on the same file system

Copying using `shutil.copy`, and subsequentially manually removing the source file fixes the issue.

Traceback:
```
$ lore fit my_app.models.product_popularity.Keras --test --score

FITTING my_app.models.product_popularity.Keras

[...]

11:21:36.644  ERROR    root:293 => Exception: Traceback (most recent call last):
  File "/home/thomas/.pyenv/versions/3.6.4/envs/my_app/bin/lore", line 11, in <module>
    sys.exit(main())
  File "/home/thomas/.pyenv/versions/3.6.4/envs/my_app/lib/python3.6/site-packages/lore/__main__.py", line 331, in main
    known.func(known, unknown)
  File "/home/thomas/.pyenv/versions/3.6.4/envs/my_app/lib/python3.6/site-packages/lore/__main__.py", line 483, in fit
    model.fit(score=parsed.score, test=parsed.test, **fit_args)
  File "/home/thomas/.pyenv/versions/3.6.4/envs/my_app/lib/python3.6/site-packages/lore/models/base.py", line 49, in fit
    x=self.pipeline.encoded_training_data.x,
  File "/home/thomas/.pyenv/versions/3.6.4/envs/my_app/lib/python3.6/site-packages/lore/pipelines/holdout.py", line 132, in encoded_training_data
    self._encoded_training_data = self.observations(self.training_data)
  File "/home/thomas/.pyenv/versions/3.6.4/envs/my_app/lib/python3.6/site-packages/lore/pipelines/holdout.py", line 110, in training_data
    self._split_data()
  File "/home/thomas/.pyenv/versions/3.6.4/envs/my_app/lib/python3.6/site-packages/lore/util.py", line 210, in wrapper
    return func(*args, **kwargs)
  File "/home/thomas/.pyenv/versions/3.6.4/envs/my_app/lib/python3.6/site-packages/lore/pipelines/holdout.py", line 234, in _split_data
    self._data = self.get_data()
  File "/home/thomas/code/my_app/my_app/pipelines/product_popularity.py", line 20, in get_data
    lore.io.download(url, cache=True, extract=True)
  File "/home/thomas/.pyenv/versions/3.6.4/envs/my_app/lib/python3.6/site-packages/lore/io/__init__.py", line 124, in download
    os.rename(temp_path, local_path)
OSError: [Errno 18] Invalid cross-device link: '/tmp/tmpwl6lvhon' -> '/home/thomas/code/my_app/data/instacart_online_grocery_shopping_2017_05_01.tar.gz'

```

I am unsure how to write tests for this. Suggestions are welcome, I would be happy to add some to this PR if that would help anyone.