### PR TITLE
Create Naive Estimator

### DIFF
--- a/lore/estimators/__init__.py
+++ b/lore/estimators/__init__.py
@@ -11,6 +11,8 @@ from lore.util import timed, before_after_callbacks
 
 
 class Base(BaseEstimator):
+    """Base class for estimators"""
+
     __metaclass__ = ABCMeta
 
     @before_after_callbacks

--- a/lore/estimators/naive.py
+++ b/lore/estimators/naive.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import
+import inspect
+import logging
+import lore
+from lore.env import require
+import lore.estimators
+from lore.util import timed, before_after_callbacks
+
+require(lore.dependencies.NUMPY)
+import numpy
+
+
+class Base(lore.estimators.Base):
+    def __init__(self):
+        super(Base, self).__init__()
+
+    @before_after_callbacks
+    @timed(logging.INFO)
+    def fit(self, x, y, **kwargs):
+        self.mean = numpy.mean(y)
+        return {}
+
+    @before_after_callbacks
+    @timed(logging.INFO)
+    def predict(self, dataframe):
+        pass
+
+    @before_after_callbacks
+    @timed(logging.INFO)
+    def evaluate(self, x, y):
+        # TODO
+        return 0
+
+    @before_after_callbacks
+    @timed(logging.INFO)
+    def score(self, x, y):
+        # TODO
+        return 0
+
+
+class Naive(Base):
+    def __init__(self):
+        frame, filename, line_number, function_name, lines, index = inspect.stack()[1]
+        super(Naive, self).__init__()
+
+
+class Regression(Base):
+    @before_after_callbacks
+    @timed(logging.INFO)
+    def predict(self, dataframe):
+        return numpy.ones(dataframe.shape[0])*self.mean
+
+
+class BinaryClassifier(Base):
+    @before_after_callbacks
+    @timed(logging.INFO)
+    def predict(self, dataframe):
+        if self.mean > 0.5:
+            return numpy.ones(dataframe.shape[0])
+        else:
+            return numpy.zeros(dataframe.shape[0])
+
+    @before_after_callbacks
+    @timed(logging.INFO)
+    def predict_proba(self, dataframe):
+        return numpy.ones(dataframe.shape[0])*self.mean

--- a/lore/estimators/naive.py
+++ b/lore/estimators/naive.py
@@ -4,7 +4,8 @@ Naive Estimator
 ****************
 A naive estimator is a useful baseline against which to benchmark more complex models.
 A naive estimator will return the mean of the outcome for regression models and
-the majority class for classification models.
+the plurality class for classification models. Note that currently only binary classification
+is implemented. For binary classifiers, the majority class will be returned
 """
 from __future__ import absolute_import
 import inspect

--- a/lore/estimators/naive.py
+++ b/lore/estimators/naive.py
@@ -69,7 +69,7 @@ class Regression(Base):
     @timed(logging.INFO)
     def predict(self, dataframe):
         """See :ref:`Base Estimator for Naive _naive_base_predict`"""
-        return numpy.ones(dataframe.shape[0])*self.mean
+        return numpy.full(dataframe.shape[0], self.mean)
 
 
 class BinaryClassifier(Base):

--- a/lore/estimators/naive.py
+++ b/lore/estimators/naive.py
@@ -1,3 +1,11 @@
+# -*- coding: utf-8 -*-
+"""
+Naive Estimator
+****************
+A naive estimator is a useful baseline against which to benchmark more complex models.
+A naive estimator will return the mean of the outcome for regression models and
+the majority class for classification models.
+"""
 from __future__ import absolute_import
 import inspect
 import logging
@@ -11,18 +19,29 @@ import numpy
 
 
 class Base(lore.estimators.Base):
+    """Base class for the Naive estimator. Implements functionality common to all Naive models"""
     def __init__(self):
         super(Base, self).__init__()
 
     @before_after_callbacks
     @timed(logging.INFO)
     def fit(self, x, y, **kwargs):
+        """
+        Fit a naive model
+        :param x: Predictors to use for fitting the data (this will not be used in naive models)
+        :param y: Outcome
+        """
         self.mean = numpy.mean(y)
         return {}
 
     @before_after_callbacks
     @timed(logging.INFO)
     def predict(self, dataframe):
+        """
+        .. _naive_base_predict
+        Predict using the model
+        :param dataframe: Dataframe against which to make predictions
+        """
         pass
 
     @before_after_callbacks
@@ -48,6 +67,7 @@ class Regression(Base):
     @before_after_callbacks
     @timed(logging.INFO)
     def predict(self, dataframe):
+        """See :ref:`Base Estimator for Naive _naive_base_predict`"""
         return numpy.ones(dataframe.shape[0])*self.mean
 
 
@@ -55,6 +75,7 @@ class BinaryClassifier(Base):
     @before_after_callbacks
     @timed(logging.INFO)
     def predict(self, dataframe):
+        """See :ref:`Base Estimator for Naive _naive_base_predict`"""
         if self.mean > 0.5:
             return numpy.ones(dataframe.shape[0])
         else:
@@ -63,6 +84,9 @@ class BinaryClassifier(Base):
     @before_after_callbacks
     @timed(logging.INFO)
     def predict_proba(self, dataframe):
+        """Predict probabilities using the model
+        :param dataframe: Dataframe against which to make predictions
+        """
         ret = numpy.ones((dataframe.shape[0], 2))
         ret[:, 0] = (1 - self.mean)
         ret[:, 1] = self.mean

--- a/lore/estimators/naive.py
+++ b/lore/estimators/naive.py
@@ -63,4 +63,7 @@ class BinaryClassifier(Base):
     @before_after_callbacks
     @timed(logging.INFO)
     def predict_proba(self, dataframe):
-        return numpy.ones(dataframe.shape[0])*self.mean
+        ret = numpy.ones((dataframe.shape[0], 2))
+        ret[:, 0] = (1 - self.mean)
+        ret[:, 1] = self.mean
+        return ret

--- a/lore/estimators/xgboost.py
+++ b/lore/estimators/xgboost.py
@@ -84,6 +84,14 @@ class Base(object):
 
     @before_after_callbacks
     @timed(logging.INFO)
+    def predict_proba(self, dataframe, ntree_limit=None):
+        if ntree_limit is None:
+            ntree_limit = self.best_ntree_limit or 0
+        with self.xgboost_lock:
+            return super(Base, self).predict_proba(dataframe, ntree_limit=ntree_limit)
+
+    @before_after_callbacks
+    @timed(logging.INFO)
     def evaluate(self, x, y):
         with self.xgboost_lock:
             return float(self.get_booster().eval(xgboost.DMatrix(x, label=y)).split(':')[-1])

--- a/lore/models/base.py
+++ b/lore/models/base.py
@@ -100,6 +100,15 @@ class Base(object):
 
     @before_after_callbacks
     @timed(logging.INFO)
+    def predict_proba(self, dataframe):
+        try:
+            probs = self.estimator.predict_proba(self.pipeline.encode_x(dataframe))
+            return probs
+        except AttributeError:
+            raise AttributeError('Estimator does not define predict_proba')
+
+    @before_after_callbacks
+    @timed(logging.INFO)
     def evaluate(self, dataframe):
         return self.estimator.evaluate(
             self.pipeline.encode_x(dataframe),

--- a/lore/models/naive.py
+++ b/lore/models/naive.py
@@ -1,0 +1,5 @@
+import lore.models.base
+
+
+class Base(lore.models.base.Base):
+    pass

--- a/tests/mocks/models.py
+++ b/tests/mocks/models.py
@@ -4,9 +4,11 @@ import lore.models
 import lore.models.keras
 import lore.models.sklearn
 import lore.models.xgboost
+import lore.models.naive
 import lore.estimators.keras
 import lore.estimators.sklearn
 import lore.estimators.xgboost
+import lore.estimators.naive
 import tests.mocks.pipelines
 
 
@@ -188,6 +190,37 @@ class OneHotBinaryClassifier(lore.models.xgboost.Base):
         super(OneHotBinaryClassifier, self).__init__(
             tests.mocks.pipelines.OneHotPipeline(),
             lore.estimators.xgboost.BinaryClassifier())
+
+    def before_fit(self, *args, **kwargs):
+        self.called_before_fit = True
+
+    def after_fit(self, *args, **kwargs):
+        self.called_after_fit = True
+
+    def before_predict(self, *args, **kwargs):
+        self.called_before_predict = True
+
+    def after_predict(self, *args, **kwargs):
+        self.called_after_predict = True
+
+    def before_evaluate(self, *args, **kwargs):
+        self.called_before_evaluate = True
+
+    def after_evaluate(self, *args, **kwargs):
+        self.called_after_evaluate = True
+
+    def before_score(self, *args, **kwargs):
+        self.called_before_score = True
+
+    def after_score(self, *args, **kwargs):
+        self.called_after_score = True
+
+
+class NaiveBinaryClassifier(lore.models.naive.Base):
+    def __init__(self):
+        super(NaiveBinaryClassifier, self).__init__(
+            tests.mocks.pipelines.NaivePipeline(),
+            lore.estimators.naive.BinaryClassifier())
 
     def before_fit(self, *args, **kwargs):
         self.called_before_fit = True

--- a/tests/mocks/pipelines.py
+++ b/tests/mocks/pipelines.py
@@ -204,3 +204,17 @@ class OneHotPipeline(lore.pipelines.holdout.Base):
 
     def get_output_encoder(self):
         return Pass('xor')
+
+
+class NaivePipeline(lore.pipelines.holdout.Base):
+    def get_data(self):
+        return pandas.DataFrame({
+            'x': [1, 2, 3]*1000,
+            'y': [0, 1, 1]*1000
+        })
+
+    def get_encoders(self):
+        return(Pass('x'))
+
+    def get_output_encoder(self):
+        return Pass('y')

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -261,5 +261,5 @@ class TestNaiveBinaryClassifier(unittest.TestCase):
     def test_probs(self):
         model = tests.mocks.models.NaiveBinaryClassifier()
         model.fit(test=True, score=True)
-        probs = model.predict_proba(model.pipeline.test_data)
+        probs = model.predict_proba(model.pipeline.test_data)[:, 1]
         self.assertTrue((numpy.abs(probs - 0.667) < 0.001).all())

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -2,6 +2,7 @@ import unittest
 
 import tests.mocks.models
 import scipy.stats
+import numpy
 
 
 class TestKeras(unittest.TestCase):
@@ -221,3 +222,38 @@ class TestOneHotBinaryClassifier(unittest.TestCase):
         self.assertTrue(model.called_before_score)
         self.assertTrue(model.called_after_score)
 
+
+class TestNaiveBinaryClassifier(unittest.TestCase):
+    def test_lifecycle(self):
+        model = tests.mocks.models.NaiveBinaryClassifier()
+        model.fit()
+        model.save()
+
+        loaded = tests.mocks.models.NaiveBinaryClassifier.load()
+        self.assertEqual(loaded.fitting, model.fitting)
+
+    def test_before_after_hooks(self):
+        model = tests.mocks.models.NaiveBinaryClassifier()
+        model.fit(test=True, score=True)
+        model.predict(model.pipeline.test_data)
+
+        self.assertTrue(model.called_before_fit)
+        self.assertTrue(model.called_after_fit)
+        self.assertTrue(model.called_before_predict)
+        self.assertTrue(model.called_after_predict)
+        self.assertTrue(model.called_before_evaluate)
+        self.assertTrue(model.called_after_evaluate)
+        self.assertTrue(model.called_before_score)
+        self.assertTrue(model.called_after_score)
+
+    def test_preds(self):
+        model = tests.mocks.models.NaiveBinaryClassifier()
+        model.fit(test=True, score=True)
+        preds = model.predict(model.pipeline.test_data)
+        self.assertTrue((preds == 1).all())
+
+    def test_probs(self):
+        model = tests.mocks.models.NaiveBinaryClassifier()
+        model.fit(test=True, score=True)
+        probs = model.predict_proba(model.pipeline.test_data)
+        self.assertTrue((numpy.abs(probs - 0.667) < 0.001).all())

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -135,6 +135,12 @@ class TestXGBoostBinaryClassifier(unittest.TestCase):
         loaded = tests.mocks.models.XGBoostBinaryClassifier.load()
         self.assertEqual(loaded.fitting, model.fitting)
 
+    def test_probs(self):
+        model = tests.mocks.models.XGBoostBinaryClassifier()
+        model.fit()
+        model.predict_proba(model.pipeline.test_data)
+        assert True
+
 
 class TestSKLearn(unittest.TestCase):
     def test_lifecycle(self):


### PR DESCRIPTION
## What
- Create a naive estimator. A naive estimator is one that just returns the mean of the outcome variable.
- Support `predict_proba` on models if the underlying estimator allows it
- Add `predict_proba` method to xgboost to access probabilities

## Why
1. Naive models are useful for benchmarking
2. We should be able to access probabilities from classifiers when available
