### PR TITLE
Add basic documentation and `predict_proba` to SKLearn Estimator

### DIFF
--- a/lore/estimators/sklearn.py
+++ b/lore/estimators/sklearn.py
@@ -66,6 +66,9 @@ class BinaryClassifier(Base):
     @before_after_callbacks
     @timed(logging.INFO)
     def predict_proba(self, dataframe):
+        """Predict probabilities using the model
+        :param dataframe: Dataframe against which to make predictions
+        """
         return self.sklearn.predict_proba(dataframe)
 
 

--- a/lore/estimators/sklearn.py
+++ b/lore/estimators/sklearn.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+scikit-learn Estimator
+****************
+This estimator allows you to use any scikit-learn estimator of your choice.
+Note that the underlying estimator can always be accessed as ``Base(estimator).sklearn``
+"""
 from __future__ import absolute_import
 import inspect
 import logging

--- a/lore/estimators/sklearn.py
+++ b/lore/estimators/sklearn.py
@@ -63,7 +63,10 @@ class Regression(Base):
 
 
 class BinaryClassifier(Base):
-    pass
+    @before_after_callbacks
+    @timed(logging.INFO)
+    def predict_proba(self, dataframe):
+        return self.sklearn.predict_proba(dataframe)
 
 
 class MutliClassifier(Base):


### PR DESCRIPTION
## What
Add basic documentation and `predict_proba` to SKLearn Estimator

## Why
1. Documentation is good
2. Access to the `predict_proba` is not currently possible directly for sklearn estimators
