### PR TITLE
Fix lore task invocation

### DIFF
--- a/lore/__main__.py
+++ b/lore/__main__.py
@@ -782,9 +782,10 @@ def task(parsed, unknown):
         sys.exit('\n%s Tasks\n%s\n  %s\n' % (lore.env.APP,'-' * (6 + len(lore.env.APP)), '\n  '.join('%s.%s: %s' % (task.__module__, task.__name__, task.main.__doc__) for task in tasks)))
 
     for task in parsed.task:
-        task = _get_fully_qualified_class(task)()
+        task_class = _get_fully_qualified_class(task)
+        instance = task_class()
         grouped, unpaired = _pair_args(unknown)
-        argspec = _get_valid_fit_args(task.main)
+        argspec = _get_valid_fit_args(instance.main)
 
         defaults = [None] * (len(argspec.args) - len(argspec.defaults)) + list(argspec.defaults)
         valid_args = dict(zip(argspec.args, defaults))
@@ -801,12 +802,12 @@ def task(parsed, unknown):
 
         if unknown_args:
             msg = ansi.bold("Valid task arguments") + ": \n%s\n" % "\n".join('  %s=%s' % i for i in valid_args.items())
-            sys.exit(ansi.error() + ' Unknown arguments: %s\n%s\n%s' % (unknown_args, msg, task.main.__doc__))
+            sys.exit(ansi.error() + ' Unknown arguments: %s\n%s\n%s' % (unknown_args, msg, instance.main.__doc__))
 
         with timer('execute %s' % task):
             print(ansi.success('RUNNING ') + task)
             logger.info('starting task: %s %s' % (task, args))
-            task.main(**cast_args)
+            instance.main(**cast_args)
 
 
 def test(parsed, unknown):

--- a/tests/mocks/tasks.py
+++ b/tests/mocks/tasks.py
@@ -1,0 +1,5 @@
+import lore.tasks.base
+
+class EchoTask(lore.tasks.base.Base):
+    def main(self, arg1=None):
+        pass

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -5,3 +5,17 @@ class TestConnection(unittest.TestCase):
         # make sure this at least gets loaded
         import lore.__main__
         self.assertTrue(True)
+
+
+class TestTask(unittest.TestCase):
+    def test_task(self):
+        import lore.__main__
+
+        args = ('task', 'tests.mocks.tasks.EchoTask', '--arg1', 'true')
+
+        with self.assertLogs('lore.__main__') as log:
+            lore.__main__.main(args)
+            self.assertEqual(log.output, [
+                "INFO:lore.__main__:starting task: " +
+                "tests.mocks.tasks.EchoTask {'arg1': 'true'}"
+            ])


### PR DESCRIPTION
## What

Fix lore task command invocation.

```
$ lore task assignments.tasks.export.Predictions
File "~.pyenv/versions/3.6.6/envs/assignments/lib/python3.6/site-packages/lore/__main__.py", line 807, in task
print(ansi.success('RUNNING ') + task)
TypeError: must be str, not Predictions
```

## Why

It was broken. 

