### PR TITLE
Enable quoting for Snowflake

### DIFF
--- a/lore/io/connection.py
+++ b/lore/io/connection.py
@@ -186,12 +186,13 @@ class Connection(object):
                 try:
                     tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.csv.gz')
                     tmp.close()
-                    batch.to_csv(tmp.name, index=False, header=False, sep='|', na_rep='\\N', quoting=csv.QUOTE_NONE, compression='gzip')
+                    batch.to_csv(tmp.name, index=False, header=False, sep='|', na_rep='\\N',
+                                 quotechar='"', quoting=csv.QUOTE_ALL, compression='gzip')
                     self._connection.connection.cursor().execute('PUT file://%(path)s @~/staged;' % {'path': tmp.name})
                     self._connection.connection.cursor().execute(
                         'COPY INTO %(table)s '
                         'FROM @~/staged '
-                        'FILE_FORMAT = (TYPE = CSV FIELD_DELIMITER = \'|\' SKIP_HEADER = 0 COMPRESSION = GZIP) '
+                        'FILE_FORMAT = (TYPE = CSV FIELD_DELIMITER = \'|\' SKIP_HEADER = 0 COMPRESSION = GZIP FIELD_OPTIONALLY_ENCLOSED_BY = \'"\') '
                         'PURGE = TRUE' % {
                             'table': table
                         }


### PR DESCRIPTION
## What
Enable quoting of fields when bulk uploading to Snowflake

## Why
Bulk upload fails when a field contains the pipe character.

Note: This version is not exposing the quote character as an argument. The reason for that is `psycopg2` does not have support for the quote character without the use of `copy_expert`. As a result, this PR went with the choice of not exposing the parameter at all. Certainly open to suggestions here.
