### PR TITLE
option to pass in selectable object to dataframe.

### DIFF
--- a/lore/stores/base.py
+++ b/lore/stores/base.py
@@ -49,7 +49,7 @@ class Base(object):
         stack = inspect.stack()
         caller = kwargs.pop('caller', stack[-2])
         instance = kwargs.pop('instance', self)
-        if isinstance(args[0], sqlalchemy.sql.Selectable):
+        if  len(args) > 0 and isinstance(args[0], sqlalchemy.sql.Selectable):
             query_string = (
                 str(args[0]).encode('utf-8') +
                 str(args[0].compile().params).encode('utf-8')

--- a/lore/stores/base.py
+++ b/lore/stores/base.py
@@ -47,10 +47,14 @@ class Base(object):
         stack = inspect.stack()
         caller = kwargs.pop('caller', stack[-2])
         instance = kwargs.pop('instance', self)
+        query_string = (
+            '__'.join(map(str, args)).encode('utf-8') +
+            str(kwargs).encode('utf-8')
+        )
 
         return '.'.join((
             instance.__module__,
             instance.__class__.__name__,
             caller.__code__.co_name,
-            hashlib.sha1(str(args).encode('utf-8') + str(kwargs).encode('utf-8')).hexdigest()
+            hashlib.sha1(query_string).hexdigest()
         ))

--- a/lore/stores/base.py
+++ b/lore/stores/base.py
@@ -3,6 +3,8 @@ from abc import ABCMeta, abstractmethod
 import hashlib
 import inspect
 
+import sqlalchemy
+
 
 class Base(object):
     __metaclass__ = ABCMeta
@@ -47,14 +49,17 @@ class Base(object):
         stack = inspect.stack()
         caller = kwargs.pop('caller', stack[-2])
         instance = kwargs.pop('instance', self)
-        query_string = (
-            '__'.join(map(str, args)).encode('utf-8') +
-            str(kwargs).encode('utf-8')
-        )
+        if isinstance(args[0], sqlalchemy.sql.Selectable):
+            query_string = (
+                str(args[0]).encode('utf-8') +
+                str(args[0].compile().params).encode('utf-8')
+            )
+        else:
+            query_string = str(args).encode('utf-8')
 
         return '.'.join((
             instance.__module__,
             instance.__class__.__name__,
             caller.__code__.co_name,
-            hashlib.sha1(query_string).hexdigest()
+            hashlib.sha1(query_string + str(kwargs).encode('utf-8')).hexdigest()
         ))


### PR DESCRIPTION
## What
- ability to pass in a `sqlalchemy.sql.Selectable` object into `lore.io.dataframe`

## Why
- so that we can feed reusable sqlalchemy queries into lore pipelines.

## Open points
- @montanalow it seems that `query_cached` does not work as expected for this case, any ideas as to why? thanks in advance.