### PR TITLE
Reading the redis URLs from the loaded redis_config instead of config…

### DIFF
--- a/lore/io/__init__.py
+++ b/lore/io/__init__.py
@@ -42,7 +42,7 @@ if redis_config:
     require(lore.dependencies.REDIS)
     import redis
 
-    for section in config.sections():
+    for section in redis_config.sections():
         vars()[section.lower()] = redis.StrictRedis(host=redis_config.get(section, 'url'),
                                                     port=redis_config.get(section, 'port'))
 


### PR DESCRIPTION
… variable for databases and aws configurations.

## What
Single line change to read the section from redis_configs. 

## Why
The redis configs in redis.cfg are read into the redis_config object and not the config object. 
