### PR TITLE
Stop logging data frame header and info by default.

### DIFF
--- a/lore/io/connection.py
+++ b/lore/io/connection.py
@@ -331,7 +331,7 @@ class Connection(object):
             return result
 
     @query_cached
-    def load_dataframe(self, key, columns):
+    def load_dataframe(self, key, columns, log_verbose=False,):
         with timer('load_dataframe'):
             frames = []
             for entry in lore.io.bucket.objects.filter(
@@ -351,10 +351,11 @@ class Connection(object):
 
             result = pandas.concat(frames)
             result.columns = columns
-            buffer = io.StringIO()
-            result.info(buf=buffer, memory_usage='deep')
-            logger.info(buffer.getvalue())
-            logger.info(result.head())
+            if log_verbose is True:
+                buffer = io.StringIO()
+                result.info(buf=buffer, memory_usage='deep')
+                logger.info(buffer.getvalue())
+                logger.info(result.head())
             return result
 
     def dataframe(self, sql=None, extract=None, filename=None, log_verbose=False, **kwargs):

--- a/lore/io/connection.py
+++ b/lore/io/connection.py
@@ -357,14 +357,14 @@ class Connection(object):
             logger.info(result.head())
             return result
 
-    def dataframe(self, sql=None, extract=None, filename=None, **kwargs):
+    def dataframe(self, sql=None, extract=None, filename=None, log_verbose=False, **kwargs):
         cache = kwargs.pop('cache', False)
         chunksize = kwargs.pop('chunksize', None)
         if chunksize and cache:
             raise ValueError('Chunking is incompatible with caching. Choose to pass either "cache" or "chunksize".')
         sql = self.__prepare(sql=sql, extract=extract, filename=filename, **kwargs)
         dataframe = self._dataframe(sql, kwargs, cache=cache, chunksize=chunksize)
-        if chunksize is None:
+        if log_verbose is True and chunksize is None:
             buffer = io.StringIO()
             dataframe.info(buf=buffer, memory_usage='deep')
             logger.info(buffer.getvalue())


### PR DESCRIPTION
## What

Stop logging data frame header and info by default but allow logging via a flag.

## Why

Even for the most basic queries this logging adds a base line 4-5ms per query.

## Results

### Without logging
```
➜  test git:(master) ✗ lore python sql_test.py
...
average runtime 2.0636 ms
```

### With logging
```
➜  test git:(master) ✗ lore python sql_test.py
...
average runtime 6.25128 ms
```

### sql_test.py

```
import lore, lore.io
import time
import numpy as np
runtimes = []

main = lore.io.main
for item_id in range(0, 1000):
    st = time.time()
    results = main.dataframe(sql='select 1;')
    runtime = round((time.time() - st)*1000.0, 2)
    runtimes.append(runtime)

avg_runtime = np.mean(runtimes)

print("average runtime {} ms".format(avg_runtime))
```