### PR TITLE
Fix CircleCI Build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
     - image: circleci/postgres:10-ram
       environment:
         - POSTGRES_USER=circleci
-        - POSTGRES_PASSWORD=circleci
+        - POSTGRES_HOST_AUTH_METHOD=trust
         - POSTGRES_DB=lore_test
     steps:
       - run: sudo chown -R circleci:circleci /usr/local/bin
@@ -93,7 +93,7 @@ jobs:
     - image: circleci/postgres:10-ram
       environment:
         - POSTGRES_USER=circleci
-        - POSTGRES_PASSWORD=circleci
+        - POSTGRES_HOST_AUTH_METHOD=trust
         - POSTGRES_DB=lore_test
     steps:
       - run: sudo chown -R circleci:circleci /usr/local/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
     - image: circleci/postgres:10-ram
       environment:
         - POSTGRES_USER=circleci
+        - POSTGRES_PASSWORD=circleci
         - POSTGRES_DB=lore_test
     steps:
       - run: sudo chown -R circleci:circleci /usr/local/bin
@@ -92,6 +93,7 @@ jobs:
     - image: circleci/postgres:10-ram
       environment:
         - POSTGRES_USER=circleci
+        - POSTGRES_PASSWORD=circleci
         - POSTGRES_DB=lore_test
     steps:
       - run: sudo chown -R circleci:circleci /usr/local/bin


### PR DESCRIPTION
## What
Set postgres password in circleci container

## Why
CircleCI run is failing with

```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD for the superuser. Use
       "-e POSTGRES_PASSWORD=password" to set it in "docker run".

       You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
       without a password. This is *not* recommended. See PostgreSQL
       documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html

Exited with code 1
```

