### PR TITLE
Jupyter depends on a greater version of core

### DIFF
--- a/lore/dependencies.py
+++ b/lore/dependencies.py
@@ -5,7 +5,7 @@ INFLECTION = ['inflection>=0.3, <0.3.99']
 JINJA = ['Jinja2>=2.9.0, <2.10.0']
 JUPYTER = [
     'jupyter>=1.0, <1.0.99',
-    'jupyter-core>=4.4.0, <4.4.99',
+    'jupyter-core>=4.6.1, <4.6.99',
 ]
 NUMPY = ['numpy>=1.14, <1.14.99']
 PANDAS = ['pandas>=0.20, <0.23.99, !=0.22.0']


### PR DESCRIPTION
## What
Bump the required version of jupyter-core

## Why
To resolve this error:
```
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.
We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.
jupyter-client 6.1.7 requires jupyter-core>=4.6.0, but you'll have jupyter-core 4.4.0 which is incompatible.
notebook 6.1.5 requires jupyter-core>=4.6.1, but you'll have jupyter-core 4.4.0 which is incompatible.
```
