### PR TITLE
docs: fix simple typo, mulitple -> multiple

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -314,7 +314,7 @@ Lore Library
 
 **Caching**
 
-- Lore provides mulitple configurable cache types, RAM, Disk, coming soon: MemCached & Redis
+- Lore provides multiple configurable cache types, RAM, Disk, coming soon: MemCached & Redis
 - Disk cache is tested with pandas to avoid pitfalls encountered serializing w/ csv, h5py, pickle
 
 **Encoders**


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `multiple` rather than `mulitple`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md