### PR TITLE
Remove useless logging

### DIFF
--- a/lore/io/connection.py
+++ b/lore/io/connection.py
@@ -134,7 +134,6 @@ class Connection(object):
         @event.listens_for(self._engine, "after_cursor_execute")
         def time_sql_calls(conn, cursor, statement, parameters, context, executemany):
             total = datetime.now() - conn.info['query_start_time'].pop(-1)
-            logger.info("SQL: %s" % total)
 
         @event.listens_for(self._engine, "connect")
         def receive_connect(dbapi_connection, connection_record):


### PR DESCRIPTION
## What
Remove useless logging that is lighting our DD $ on fire.

We have a legacy service lighting money on fire and this is a stop gap until we can replace it in Q4/Q1. 

## Why

https://instacart.datadoghq.com/dashboard/n9r-94j-wwx/ads-infra-dashboard?fullscreen_end_ts=1663956214224&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1661364214224&fullscreen_widget=6719388726614565&from_ts=1664298847946&to_ts=1664302447946&live=true

Our lore service is hammering us on DD costs. 
![Screen Shot 2022-09-27 at 2 22 44 PM](https://user-images.githubusercontent.com/92758058/192606234-873a4aca-98de-497c-921b-d290965747de.png)


